### PR TITLE
Django's File class expects an attribute 'name', so I renamed the _name

### DIFF
--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -275,7 +275,7 @@ class SFTPStorage(Storage):
 
 class SFTPStorageFile(File):
     def __init__(self, name, storage, mode):
-        self._name = name
+        self.name = name
         self._storage = storage
         self._mode = mode
         self._is_dirty = False
@@ -285,12 +285,12 @@ class SFTPStorageFile(File):
     @property
     def size(self):
         if not hasattr(self, '_size'):
-            self._size = self._storage.size(self._name)
+            self._size = self._storage.size(self.name)
         return self._size
 
     def read(self, num_bytes=None):
         if not self._is_read:
-            self.file = self._storage._read(self._name)
+            self.file = self._storage._read(self.name)
             self._is_read = True
 
         return self.file.read(num_bytes)
@@ -304,5 +304,5 @@ class SFTPStorageFile(File):
 
     def close(self):
         if self._is_dirty:
-            self._storage._save(self._name, self.file.getvalue())
+            self._storage._save(self.name, self.file.getvalue())
         self.file.close()


### PR DESCRIPTION
attribute to match.  The equivalent change for the FTP backend was
made here:
https://github.com/monash-merc/django-storages/commit/d34077a37bf767a633b07f6f8abe2290f816765f
